### PR TITLE
Allow plugins to return a list of types

### DIFF
--- a/packages/gatsby-transformer-yaml-full/gatsby-node.js
+++ b/packages/gatsby-transformer-yaml-full/gatsby-node.js
@@ -70,12 +70,12 @@ exports.onCreateNode = async (helpers, { plugins }) => {
 
   const types = []
 
-  for (let { resolve, pluginOptions } of plugins) {
-    let plugins = require(resolve)
+  for (let {resolve, pluginOptions} of plugins) {
+    const plugin = require(resolve);
+    const results = plugin(helpers, pluginOptions);
     // The module may return a single type, or an Array of types
-    for (let plugin of Array.isArray(plugins) ? plugins : [plugins]){
-      const { options, tag } = plugin(helpers, pluginOptions)
-      types.push(new jsYaml.Type(tag, options))
+    for (let {options, tag} of Array.isArray(results) ? results : [results]) {
+      types.push(new jsYaml.Type(tag, options));
     }
   }
 

--- a/packages/gatsby-transformer-yaml-full/gatsby-node.js
+++ b/packages/gatsby-transformer-yaml-full/gatsby-node.js
@@ -73,7 +73,8 @@ exports.onCreateNode = async (helpers, { plugins }) => {
   for (let {resolve, pluginOptions} of plugins) {
     const plugin = require(resolve);
     const results = plugin(helpers, pluginOptions);
-    // The module may return a single type, or an Array of types
+    
+    // The plugin function may return a single type, or an array of types
     for (let {options, tag} of Array.isArray(results) ? results : [results]) {
       types.push(new jsYaml.Type(tag, options));
     }

--- a/packages/gatsby-transformer-yaml-full/gatsby-node.js
+++ b/packages/gatsby-transformer-yaml-full/gatsby-node.js
@@ -71,9 +71,12 @@ exports.onCreateNode = async (helpers, { plugins }) => {
   const types = []
 
   for (let { resolve, pluginOptions } of plugins) {
-    const plugin = require(resolve)
-    const { options, tag } = plugin(helpers, pluginOptions)
-    types.push(new jsYaml.Type(tag, options))
+    let plugins = require(resolve)
+    // The module may return a single type, or an Array of types
+    for (let plugin of Array.isArray(plugins) ? plugins : [plugins]){
+      const { options, tag } = plugin(helpers, pluginOptions)
+      types.push(new jsYaml.Type(tag, options))
+    }
   }
 
   self.configureSchema(types)


### PR DESCRIPTION
Closes #4. I've tested this with an array plugin, and it definitely works, but I don't have formal tests.